### PR TITLE
added filters for wsj.com

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -135,3 +135,9 @@ computerworld.com###superadunit
 
 #foxnews.com
 foxnews.com###sponsored-stories
+
+#wsj.com
+wsj.com##DIV[class*="nativo-placement"]
+wsj.com##IFRAME[id*="_mN_dy"]
+wsj.com##DIV[class*="sponsoredSections"]
+

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -141,3 +141,7 @@ wsj.com##DIV[class*="nativo-placement"]
 wsj.com##IFRAME[id*="_mN_dy"]
 wsj.com##DIV[class*="sponsoredSections"]
 
+#time.com
+time.com###celtra-banner
+
+


### PR DESCRIPTION
these are filters for unhidden ads on wsj.com
the checksum still does not look right for me. I updated bash with `brew update` and `brew install bash`, now when typing `bash --version` it  does tell me it's 4.x . However, `echo $BASH_VERSION` tells me "3.2.57(1)-release". This might be the problem? 
