### PR TITLE
two ads on facebook filter adn #381

### DIFF
--- a/checksums/ublock0.txt
+++ b/checksums/ublock0.txt
@@ -5,7 +5,7 @@
 ef059f65b5460a6b575efc7753ac28b8 assets/ublock/privacy.txt
 2f5be8267d42a23f5035cea088f43a0f assets/ublock/resources.txt
 59e01da2056e9b5875b00d4f74fd9bc1 assets/ublock/unbreak.txt
-f6dfac339aab548c5260656aabade5f1 assets/ublock/adnauseam.txt
+1704b997240144cbeec4563f2a615235 assets/ublock/adnauseam.txt
 b4a9425d2378129c5ce885a8dfd96c3c assets/thirdparties/easylist-downloads.adblockplus.org/easylist.txt
 8730a911472ab8265ff61d7a07ce6a67 assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
 d91867c9f3bec71f1dce75864ef8e1ba assets/thirdparties/mirror1.malwaredomains.com/files/justdomains

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -20,6 +20,10 @@ haaretz.co.il##[id^="dclk"]
 
 # facebook
 facebook.com##DIV[id^="substream_"] ._5jmm[data-dedupekey][data-cursor][data-xt][data-xt-vimpr="1"][data-ftr="1"][data-fte="1"]
+facebook.com##div[class*="ego_unit_container"]
+facebook.com##div[id*="pagelet_ego_pane"]
+
+
 
 # piratebay
 ##iframe[src*="adxprts.com"]
@@ -170,5 +174,3 @@ bitcoinist.net##a[href*='bitstarz']
 
 usatoday.com##DIV#module-position-8
 usatoday.com##DIV.taboola-sidebar-content
-
-


### PR DESCRIPTION
https://github.com/dhowe/AdNauseam/issues/381 noticed to big ads right on the top of facebook, they just seemed so wrong to me, though uBlock does not block them (yet i guess) either.

<img width="331" alt="screen shot 2016-10-21 at 21 43 46" src="https://cloud.githubusercontent.com/assets/14130931/19616044/d5bcaebc-97d7-11e6-9f6e-a8fac6847947.png">
