### PR TITLE
fix for pc mag 

### DIFF
--- a/checksums/ublock0.txt
+++ b/checksums/ublock0.txt
@@ -5,7 +5,7 @@ bb5719ac3f8a19d5e6e0209443ec0b42 assets/ublock/filters.txt
 ef059f65b5460a6b575efc7753ac28b8 assets/ublock/privacy.txt
 d2febf88aaa1d8f438d2901d688fcf05 assets/ublock/resources.txt
 0396f5154e50b0c2dad79a5cc8875de6 assets/ublock/unbreak.txt
-aff7f495a85757bdd74a43489804d18f assets/ublock/adnauseam.txt
+f6acb20a9982703e361915c0b0c0ee95 assets/ublock/adnauseam.txt
 501713c9c084f25b2cc6d8c25fc5c946 assets/thirdparties/easylist-downloads.adblockplus.org/easylist.txt
 80d4eca45f71b39cae5e92f3740ee92f assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
 eb8c6ed331aa13cde7beb51073104108 assets/thirdparties/mirror1.malwaredomains.com/files/justdomains

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -113,6 +113,9 @@ si.com#@#.cm-ad
 #pcmag.com/
 ##img[src*="ziffty"]
 www.pcmag.com##.deal-widget
+pcmag.com##*[class*="flite"]
+pcmag.com##DIV[id*="pcmedia"]
+
 
 #sfgate.com
 www.sfgate.com##.dealnews


### PR DESCRIPTION
https://github.com/dhowe/AdNauseam/issues/381

- fix for consistent overlay ad 
- prevents a overflow hidden script that was triggered by this ad 
- gets rid of white space on top of page