### PR TITLE
tweak

### DIFF
--- a/checksums/ublock0.txt
+++ b/checksums/ublock0.txt
@@ -5,7 +5,7 @@ cadc15e72055199b194392c3e6814948 assets/ublock/badware.txt
 fd9c595b155f372080617bc56fa9343f assets/ublock/privacy.txt
 f3b91943de7b8662b4e2bdc0d68fc706 assets/ublock/resources.txt
 ca1ab39636e516b2c668d7a82b0bd5c9 assets/ublock/unbreak.txt
-c8448c6eadd66dae5ddd722108cfb039 assets/ublock/adnauseam.txt
+4b764c66036720f85b700a26853d2359 assets/ublock/adnauseam.txt
 d7343b98d0a008e95ec5b840e9cd8e17 assets/thirdparties/easylist-downloads.adblockplus.org/easylist.txt
 a30e34aa14022b2ba425dcacf5e3b908 assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
 54a280b1f54c35772383ee9c9ef062a1 assets/thirdparties/mirror1.malwaredomains.com/files/justdomains

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -65,16 +65,16 @@ columbiagreenemedia.com###sawyer_container
 ##DIV[id*="IndexFlashBg"]
 163.com##.mod_zheye
 ##iframe[src*='kaolaad']
-##iframe[src*='jd.com']
+163.com##iframe[src*='jd.com']
 ##iframe[src*='g.163.com']
-##a[href*='AID']
+163.com##a[href*='AID']
 ##a[href*='kaolaad']
 
 # sohu.com
 ||images.sohu.com/bill/s2015/jscript/lib/sjs/matrix/ad/form/bigView.js
-##DIV[class^="ad_"]
-##DIV[id^="ad_"]
-##DIV[id^="beans_"]
+sohu.com##DIV[class^="ad_"]
+sohu.com##DIV[id^="ad_"]
+sohu.com##DIV[id^="beans_"]
 ##DIV[class^="TurnAD"]
 ##iframe[src*='taobaocdn']
 ##span[id^="_AdSame"]


### PR DESCRIPTION
`sohu.com##DIV[class^="ad_"]`
The above rule should fix the issue in the following ticket: https://github.com/dhowe/AdNauseam/issues/824
Other changes are possible bad rules to be applied for all sites.

I will follow up the ticket once the change is live.