### PR TITLE
Update rules from trackers

### DIFF
--- a/checksums/ublock0.txt
+++ b/checksums/ublock0.txt
@@ -5,7 +5,7 @@ cadc15e72055199b194392c3e6814948 assets/ublock/badware.txt
 fd9c595b155f372080617bc56fa9343f assets/ublock/privacy.txt
 f3b91943de7b8662b4e2bdc0d68fc706 assets/ublock/resources.txt
 ca1ab39636e516b2c668d7a82b0bd5c9 assets/ublock/unbreak.txt
-2368ea658d4aee6a60b8e7a6bfc9c405 assets/ublock/adnauseam.txt
+318d47483d0d0c89a8c77c30c9c286ac assets/ublock/adnauseam.txt
 d7343b98d0a008e95ec5b840e9cd8e17 assets/thirdparties/easylist-downloads.adblockplus.org/easylist.txt
 a30e34aa14022b2ba425dcacf5e3b908 assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
 54a280b1f54c35772383ee9c9ef062a1 assets/thirdparties/mirror1.malwaredomains.com/files/justdomains

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -247,25 +247,29 @@ optoclick.net##.vjs-poster
 ||rtax.criteo.com
 ||b3.mookie1.com
 
-#Trackers
-||scorecardresearch.com
+#Trackers[Verified]
+||scorecardresearch.com^$third-party
+||assets.adobedtm.com^third-party
+||postrelease.com^
+||grvcdn.com/moth-min.js
+||pointroll.com^
+||postrelease.com^
+||effectivemeasure.net^
+||advertising.com^
+||adnxs.com^
+||revsci.net^
+||pubmatic.com/
+||gravity.com^*/beacons/
+||adsafeprotected.com
+/mbox.orig.js
+/tacoda.
+/tacoda_
+
+# Trackers added according to better.fyi/trackers
 ||tiqcdn.com
 ||ak.sail-horizon.com^
-||assets.adobedtm.com^
-||a.postrelease.com^
-/mbox.orig.js
-||speed.pointroll.com^
-||adnxs.com^
-||me-cdn.effectivemeasure.net^
 ||s.ntv.io^
 ||plugin.mediavoice.com^
-||api.gravity.com^
-||b.grvcdn.com^
-||dtm.advertising.com
-||an.tacoda.net
-||revsci.net
-||image2.pubmatic.com/
-||adsafeprotected.com
 ||sync.go.sonobi.com/us.gif
 
 # Tracking pixel


### PR DESCRIPTION
Triggered by this ticket https://github.com/dhowe/AdNauseam/issues/870, I have double checked all the rules for #Trackers.

Now the rules under #Trackers[verified] are rules that exist in the current lists(EasyPrivacy, Peter Lowe’s Ad and tracking server list).

Rules under "Trackers added according to better.fyi/trackers" were originally added based on the information from better.fyi/trackers. But as the case from tiqcdn.com shows, they might cause troubles and are not safe to block. I'm not sure about whether we should simply removing them or not. So I have first classified them and we can decide what we want to do with the rules from better.fyi/trackers ...