### PR TITLE
Fix 2 Redundancies

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -211,7 +211,6 @@ www.overclockers.ru##img[src^="/images/HP_"]
 ##div[id^="yandex_ad"]
 
 # gocurrycracker.com
-###amzn_assoc_ad_0
 ##*[id^="amzn_assoc_ad"]
 ##iframe[src*="amazon-adsystem.com"]
 ##.gqsvbds-single
@@ -290,7 +289,6 @@ google.*##.mnr-c.rl-qs-crs-t._Db > ._gt:has(._mB)
 ||postrelease.com^
 ||grvcdn.com/moth-min.js
 ||pointroll.com^
-||postrelease.com^
 ||effectivemeasure.net^
 ||advertising.com^
 ||adnxs.com^


### PR DESCRIPTION
Replace the bracketed [...] placeholders with your own information.

### URL(s) where the issue occurs

N/A

### Describe the issue

Ran it through a Redundancy Checker by Famlam on the EasyList Forums and found two rules that could be removed

```
||postrelease.com^ has been made redundant by ||postrelease.com^
###amzn_assoc_ad_0 has been made redundant by ##*[id^="amzn_assoc_ad"]
```

### Screenshot(s)

N/A

### Versions

- Browser/version: Vivaldi 1.11.917.22
- AdNauseam version: 3.3.403

### Settings

N/A

### Notes
There was also 73 warnings but I wasn't sure about them so I'll leave that to somebody else if they want to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dhowe/uassets/57)
<!-- Reviewable:end -->
