### PR TITLE
Fix AdNauseam#1445

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -367,6 +367,10 @@ bitcohitz.com##.foot_banners
 # dailyfreebits.com
 dailyfreebits.com##*[id^="sticky-banner"]
 
+# bitcoin.treasurebits.net
+bitcoin.treasurebits.net##[id^="data_"]
+bitcoin.treasurebits.net##iframe[src="about:blank"]
+
 ##################### Blocking rules ########################
 
 # 4archive.prg


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://bitcoin.treasurebits.net`

### Describe the issue

Visible ads was found in the website.

### Screenshot(s)

![01](https://user-images.githubusercontent.com/24424527/50732484-3bb64880-11b7-11e9-9ced-6c1d16e9d35a.png)

![02](https://user-images.githubusercontent.com/24424527/50732487-41ac2980-11b7-11e9-85a3-0c22475dd85c.png)

![03](https://user-images.githubusercontent.com/24424527/50732488-453fb080-11b7-11e9-9a8b-910db51c849b.png)


### Versions

- Browser/version:
  a). Chrome Version 70.0.3538.110 (Official Build) (64-bit)
  b). Firefox 63.0.3 (64-bit)

- AdNauseam version: AdNauseam3.7.802


### Settings

OS/version: Windows 10 Enterprise
Other extensions you have installed: N/A
