### PR TITLE
Fix AdNauseam#1426 & 1427

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -371,6 +371,10 @@ dailyfreebits.com##*[id^="sticky-banner"]
 bitcoin.treasurebits.net##[id^="data_"]
 bitcoin.treasurebits.net##iframe[src="about:blank"]
 
+# 9anime.to
+www2.9anime.to##*[src*="inc"]
+www2.9anime.to##*[class*="crop"]
+
 ##################### Blocking rules ########################
 
 # 4archive.prg
@@ -525,6 +529,9 @@ bitcoin.treasurebits.net##iframe[src="about:blank"]
 ||bitraffic.com^$third-party
 ||p3.adhitzads.com^
 ||coinad.com/ads^
+
+# cnbc.com
+||ads-pd.nbcuni.com^
 
 ##################### Exceptions below here ########################
 

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -345,35 +345,29 @@ neoseeker.com##.wrapper > .creative
 neoseeker.com###stitialv2
 neoseeker.com###leaderboardTop.section-ad
 
-#theguardian.com
 theguardian.com##.adverts--within-unbranded .badge
 theguardian.com##.paidfor-container .badge
 theguardian.com##.paid-content .badge
 
 hk.yahoo.com###adive_vm
 
-#weather.com
 weather.com##.wx-adWrapper
 
 # adbtc.top
 ##iframe[src*="-ads.com"]
 ##iframe[src*="neon.today"]
 
-# bitcohitz.com
 bitcohitz.com###wcfloatDiv
 bitcohitz.com##*[id^="sticky-banner"]
 bitcohitz.com##.foot_banners
 
-# dailyfreebits.com
 dailyfreebits.com##*[id^="sticky-banner"]
 
-# bitcoin.treasurebits.net
 bitcoin.treasurebits.net##[id^="data_"]
 bitcoin.treasurebits.net##iframe[src="about:blank"]
 
-# 9anime.to
-www2.9anime.to##*[src*="inc"]
-www2.9anime.to##*[class*="crop"]
+9anime.to##*[src*="inc"]
+9anime.to##*[class*="crop"]
 
 ##################### Blocking rules ########################
 


### PR DESCRIPTION

### URL(s) where the issue occurs

`[https://www1.9anime.to/watch/bloom-into-you.wmj4/op60pj]`
`[https://www.cnbc.com/video/2018/11/07/president-trump-cnns-jim-acosta-have-heated-exchange.html]`

### Describe the issue

Ads are shown on 9anime.to and cnbc.com

### Screenshot(s)

![screen shot 2019-01-26 at 5 29 32 pm](https://user-images.githubusercontent.com/24424527/51785265-1d2ce700-2190-11e9-8418-115df043aa0a.png)

![screen shot 2019-01-26 at 5 13 46 pm](https://user-images.githubusercontent.com/24424527/51785215-4f8a1480-218f-11e9-9aa6-f3069cfb0de6.png)


### Versions
Browser/version:
a). Chrome Version 70.0.3538.110 (Official Build) (64-bit)
b). Firefox 63.0.3 (64-bit)

AdNauseam version: AdNauseam3.7.802

### Settings
OS/version: Windows 10 Enterprise
Other extensions you have installed: N/A
