### PR TITLE
Fix AdNauseam#1408

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -375,6 +375,8 @@ bitcoin.treasurebits.net##iframe[src="about:blank"]
 9anime.to##*[class*="crop"]
 9anime.to##*[src*="interbuzznews"]
 9anime.to##*[href*="revrtb"]
+
+www.rockpapershotgun.com##*[id^="google_ads_iframe_"]
 ##################### Blocking rules ########################
 
 # 4archive.prg
@@ -573,6 +575,3 @@ bitcoin.treasurebits.net##iframe[src="about:blank"]
 #@#[src*="data:"]
 #@#[style*="base64"]
 #@#[style*="blob:"]
-
-# rockpapershotgun
-||cdn.gamer-network.net/plugins/dfp$domain=rockpapershotgun.com


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.rockpapershotgun.com/`

### Describe the issue

Some ads are not collected in Chrome and Firefox. Try to remove a blocking rules and add a filter rule, then Chrome can collect ads in the website. Requested by Sally that I should commit the source firstly.

### Screenshot(s)

![50733300-1e3cab00-11c6-11e9-9832-cc5a2b7303f2](https://user-images.githubusercontent.com/24424527/53283703-273d0800-3785-11e9-9896-105ef3640333.png)


### Your settings
* OS/version: Windows 10 Enterprise
* Browser/version:
  
  1. Chrome Version 70.0.3538.110 (Official Build) (64-bit)
  2. Firefox 63.0.3 (64-bit)
* AdNauseam version: AdNauseam3.7.802
* Other extensions you have installed: N/A

##### Your filter lists
AdNauseam filters​​​​
EasyList​​​​​
EasyPrivacy​​​​​
uBlock filters​​​​​

uBlock filters – Badware risks​​​​​
uBlock filters – Privacy
uBlock filters – Resource abuse​​​​​
uBlock filters – Unbreak​​​​​
My filters​​​​​

Malware Domain List​​​​​
Malware domains

### Your location/country
Hong Kong
